### PR TITLE
[Issue 13] Adjusting the Access-Control-Allow-Methods rule to only pass GET OPTIONS types and fail on DELETE, PATCH, POST, or PUT.

### DIFF
--- a/dist/index.php
+++ b/dist/index.php
@@ -349,7 +349,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                                                 </dt>
                                                 <dd class="mt-1 text-sm leading-5 text-gray-900">
                                                     <?php if (is_array($validation['msg'])) : ?>
-                                                        <ul>
+                                                        <ul class="list-inside list-disc pl-3">
                                                             <?php foreach ($validation['msg'] as $msg) : ?>
                                                                 <li><?php echo $msg; ?></li>
                                                             <?php endforeach; ?>


### PR DESCRIPTION
Resolves #13 